### PR TITLE
Update learning path to learning lab to avoid InnerSource Commons wordmark on "InnerSource learning path"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center"><a href="https://lab.github.com/"><img alt="Learning Lab bot" src="https://user-images.githubusercontent.com/16547949/62085817-83232580-b22a-11e9-8693-7c54205b04e5.png"></a></p>
 
-<h1 align="center">Learning Path: InnerSource: theory to practice</h1>
+<h1 align="center">Learning Lab: InnerSource: theory to practice</h1>
 
-This repository powers the Learning Path [_InnerSource: theory to practice_](https://lab.github.com/githubtraining/innersource:-theory-to-practice). 
+This repository powers the Learning Lab [_InnerSource: theory to practice_](https://lab.github.com/githubtraining/innersource:-theory-to-practice). 
 
 ## Contribute
 
@@ -12,6 +12,6 @@ We :heart: our community and take great care to ensure it is fun, safe and rewar
 
 ## License
 
-All Learning Lab learning path repositories are licensed under [CC-BY-4.0](../LICENSE) (c) 2020 GitHub, Inc. The template repositories associated with each course may have different licenses.
+All Learning Lab learning lab repositories are licensed under [CC-BY-4.0](../LICENSE) (c) 2020 GitHub, Inc. The template repositories associated with each course may have different licenses.
 
 When using the GitHub logos, be sure to follow the [GitHub logo guidelines](https://github.com/logos)

--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,7 @@
 title: 'InnerSource: theory to practice'
 description: >-
   Learn about the concept of InnerSource and put it to use in this carefully
-  crafted learning path.
+  crafted learning lab.
 steps:
   - link: 'https://resources.github.com/whitepapers/introduction-to-innersource/'
     title: An introduction to InnerSource

--- a/course-details.md
+++ b/course-details.md
@@ -1,1 +1,1 @@
-Learn about the concept of InnerSource and put it to use in this carefully crafted learning path.
+Learn about the concept of InnerSource and put it to use in this carefully crafted learning lab.


### PR DESCRIPTION
[learning path wordmark.pdf](https://github.com/githubtraining/innersource-theory-to-practice/files/10680074/learning.path.wordmark.pdf)
